### PR TITLE
graceful shutdown init

### DIFF
--- a/cfg/config.yml
+++ b/cfg/config.yml
@@ -20,6 +20,8 @@ cors:
     - "X-Timestamp"
     - "X-Request-UUID"
     - "Content-Type"
+  allow_credentials: true
+  max_age_seconds: 3600
 
 # Rate Limiting
 rate_limiter:
@@ -53,3 +55,7 @@ metrics:
 logging:
   level: "debug"
   format: "json"
+
+# Graceful shutdown
+graceful_shutdown:
+ grace_time_seconds: 30

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,9 +21,11 @@ func (s Server) ReadTimeout() time.Duration  { return time.Duration(s.ReadTimeou
 func (s Server) WriteTimeout() time.Duration { return time.Duration(s.WriteTimeoutSec) * time.Second }
 
 type CORS struct {
-	AllowedOrigins []string `mapstructure:"allowed_origins"`
-	AllowedMethods []string `mapstructure:"allowed_methods"`
-	AllowedHeaders []string `mapstructure:"allowed_headers"`
+	AllowedOrigins   []string `mapstructure:"allowed_origins"`
+	AllowedMethods   []string `mapstructure:"allowed_methods"`
+	AllowedHeaders   []string `mapstructure:"allowed_headers"`
+	AllowCredentials bool     `mapstructure:"allow_credentials"`
+	MaxAgeSeconds    int      `mapstructure:"max_age_seconds"`
 }
 
 type RateLimiter struct {
@@ -56,14 +58,19 @@ type Logging struct {
 	Format string `mapstructure:"format"`
 }
 
+type GracefulShutdown struct {
+	GraceTimeSeconds int `mapstructure:"grace_time_seconds"`
+}
+
 type Config struct {
-	Server      Server      `mapstructure:"server"`
-	CORS        CORS        `mapstructure:"cors"`
-	RateLimiter RateLimiter `mapstructure:"rate_limiter"`
-	Memcached   Memcached   `mapstructure:"memcached"`
-	Files       Files       `mapstructure:"files"`
-	Metrics     Metrics     `mapstructure:"metrics"`
-	Logging     Logging     `mapstructure:"logging"`
+	Server           Server           `mapstructure:"server"`
+	CORS             CORS             `mapstructure:"cors"`
+	RateLimiter      RateLimiter      `mapstructure:"rate_limiter"`
+	Memcached        Memcached        `mapstructure:"memcached"`
+	Files            Files            `mapstructure:"files"`
+	Metrics          Metrics          `mapstructure:"metrics"`
+	Logging          Logging          `mapstructure:"logging"`
+	GracefulShutdown GracefulShutdown `mapstructure:"graceful_shutdown"`
 }
 
 func Load() (Config, error) {

--- a/internal/handler/middleware.go
+++ b/internal/handler/middleware.go
@@ -26,7 +26,6 @@ func CORS(cfg CORSConfig) func(http.Handler) http.Handler {
 	if len(cfg.AllowedHeaders) == 0 {
 		cfg.AllowedHeaders = DefaultCORSHeaders
 	}
-
 	if len(cfg.AllowedOrigins) == 0 {
 		c := cors.AllowAll()
 		return func(next http.Handler) http.Handler { return c.Handler(next) }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,185 +10,198 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const namespace = "pdf_service" // можно в cfg вынести
+
+// startAt - время старта процесса
+var startAt time.Time = time.Now()
+
+// once — чтобы безопасно навесить метрики один раз
+var once sync.Once
+
 var (
 	// Время обработки одного PDF-файла (в секундах)
 	fileProcessingTimeSeconds = promauto.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "file_processing_time_seconds",
 		Help:      "Время обработки одного PDF-файла (в секундах)",
 	}, []string{"result"})
 
 	// Размер загруженных файлов (в байтах)
 	fileSizeBytes = promauto.NewSummary(prometheus.SummaryOpts{
-		Namespace: "calculator_service",
+		Namespace: namespace,
 		Name:      "file_size_bytes",
 		Help:      "Размер загруженных файлов (в байтах)",
 	})
 
 	// Количество успешно загруженных файлов
 	fileUploadSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "file_upload_success_count",
 		Help:      "Количество успешно загруженных файлов",
 	})
 
 	// Количество ошибок при загрузке файлов
 	fileUploadErrorCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "file_upload_error_count",
 		Help:      "Количество ошибок при загрузке файлов",
 	})
 
 	// Текущее количество файлов, находящихся в процессе обработки
 	currentFilesInProgress = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "current_files_in_progress",
 		Help:      "Текущее количество файлов, находящихся в процессе обработки",
 	})
 
 	// Количество операций в секунду
 	operationsPerSecond = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "operations_per_second",
 		Help:      "Количество операций в секунду",
 	})
 
 	// Длина очереди задач, ожидающих обработки.
 	queueLength = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "queue_length",
 		Help:      "Длина очереди задач, ожидающих обработки",
 	})
 
 	// Задержка между постановкой задачи в очередь и началом её обработки (в секундах)
 	workerQueueDelaySeconds = promauto.NewSummary(prometheus.SummaryOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "worker_queue_delay_seconds",
 		Help:      "Задержка между постановкой задачи в очередь и началом её обработки (в секундах)",
 	})
 
 	// Время работы сервера (в секундах)
-	serverUptimeSeconds = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "pdf_service",
-		Name:      "server_uptime_seconds",
-		Help:      "Время работы сервера (в секундах)",
-	})
+	serverUptimeSeconds = promauto.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "server_uptime_seconds",
+			Help:      "Время работы сервера (в секундах)",
+		},
+		func() float64 {
+			return time.Since(startAt).Seconds()
+		},
+	)
 
 	// Использование оперативной памяти (в байтах)
 	memoryUsageBytes = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "memory_usage_bytes",
 		Help:      "Использование оперативной памяти (в байтах)",
 	})
 
 	// Средняя загрузка ЦПУ за последнюю минуту
 	cpuLoadAverage = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "cpu_load_average",
 		Help:      "Средняя загрузка ЦПУ за последнюю минуту",
 	})
 
 	// Количество попыток повторной обработки при возникновении ошибок
 	retryAttempts = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "retry_attempts",
 		Help:      "Количество попыток повторной обработки при возникновении ошибок",
 	})
 
 	// Счётчик статусов операций (NEW, PROGRESS, DONE, ERROR)
 	operationStatusCounts = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "operation_status_counts",
 		Help:      "Счётчик статусов операций (NEW, PROGRESS, DONE, ERROR)",
 	}, []string{"status"})
 
 	// Количество успешных обращений к Memcached
 	cacheHits = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "cache_hits",
 		Help:      "Количество успешных обращений к Memcached",
 	})
 
 	// Количество пропущенных записей в Memcached.
 	cacheMisses = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "cache_misses",
 		Help:      "Количество пропущенных записей в Memcached",
 	})
 
 	// Количество превышений лимита запросов
 	rateLimitExceededCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "rate_limit_exceeded_count",
 		Help:      "Количество превышений лимита запросов",
 	})
 
 	// Количество запросов от каждого IP-адреса
 	requestCountByIP = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "request_count_by_ip",
 		Help:      "Количество запросов от каждого IP-адреса",
 	}, []string{"ip"})
 
 	// Количество успешных извлечений данных из PDF-файлов
 	dataExtractionSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "data_extraction_success_count",
 		Help:      "Количество успешных извлечений данных из PDF-файлов",
 	})
 
 	// Количество ошибок при извлечении данных
 	dataExtractionErrorCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "data_extraction_error_count",
 		Help:      "Количество ошибок при извлечении данных",
 	})
 
 	// Время извлечения данных из одного PDF-файла (в секундах)
 	dataExtractionTimeSeconds = promauto.NewSummary(prometheus.SummaryOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "data_extraction_time_seconds",
 		Help:      "Время извлечения данных из одного PDF-файла (в секундах)",
 	})
 
 	// Количество успешных сравнений "до/после"
 	comparisonSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "comparison_success_count",
 		Help:      "Количество успешных сравнений до/после",
 	})
 
 	// Количество ошибок при сравнении "до/после"
 	comparisonErrorCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "comparison_error_count",
 		Help:      "Количество ошибок при сравнении до/после",
 	})
 
 	// Время выполнения сравнения "до/после" (в секундах)
 	comparisonTimeSeconds = promauto.NewSummary(prometheus.SummaryOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "comparison_time_seconds",
 		Help:      "Время выполнения сравнения до/после (в секундах)",
 	})
 
 	// Количество успешных экспортов отчётов
 	exportSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "export_success_count",
 		Help:      "Количество успешных экспортов отчётов",
 	})
 
 	// Количество ошибок при экспорте отчётов
 	exportErrorCount = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "export_error_count",
 		Help:      "Количество ошибок при экспорте отчётов",
 	})
 
 	// Время выполнения экспорта отчётов (в секундах)
 	exportTimeSeconds = promauto.NewSummary(prometheus.SummaryOpts{
-		Namespace: "pdf_service",
+		Namespace: namespace,
 		Name:      "export_time_seconds",
 		Help:      "Время выполнения экспорта отчётов (в секундах)",
 	})
@@ -231,20 +245,6 @@ func UpdateQueueLength(length float64) {
 // UpdateWorkerQueueDelay обновляет задержку между постановкой задачи в очередь и началом её обработки
 func UpdateWorkerQueueDelay(delay float64) {
 	workerQueueDelaySeconds.Observe(delay)
-}
-
-// UpdateServerUptime обновляет время работы сервера
-func UpdateServerUptime() {
-	go func() {
-		startTime := time.Now()
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-
-		for range ticker.C {
-			uptime := time.Since(startTime).Seconds()
-			serverUptimeSeconds.Set(uptime)
-		}
-	}()
 }
 
 // UpdateMemoryUsage обновляет использование оперативной памяти
@@ -332,6 +332,9 @@ func UpdateExportTime(duration float64) {
 	exportTimeSeconds.Observe(duration)
 }
 
-func InitMetrics() {
-	http.Handle("/metrics", promhttp.Handler())
+// InitMetricsOn подготавливает и вешает /metrics на HTTP роутер без горутин
+func InitMetricsOn(mux *http.ServeMux) {
+	once.Do(func() {
+		mux.Handle("/metrics", promhttp.Handler())
+	})
 }


### PR DESCRIPTION
Привёл в порядок main.go, исправил метрики (теперь работают без горутин, и шатдаунить ничего не надо), добавил эндпоинт /slow для проверки graceful shutdown: в одном терминале запустить сервис, в другом — запрос к /slow, затем завершить выполнение (Ctrl+C в PowerShell, если Windows) — запрос должен корректно завершиться до остановки сервера. Поправил cfg, добавил то что надо было от CORS, и вынес 1 поле для Graceful shutdown. Там я бы еще константу из метрик вынес.